### PR TITLE
Fix searchsorted in place operation

### DIFF
--- a/nflows/utils/torchutils.py
+++ b/nflows/utils/torchutils.py
@@ -133,8 +133,13 @@ def create_random_binary_mask(features):
 
 
 def searchsorted(bin_locations, inputs, eps=1e-6):
+    bin_locations = bin_locations.detach().clone()
     bin_locations[..., -1] += eps
-    return torch.sum(inputs[..., None] >= bin_locations, dim=-1) - 1
+    idx = (torch.searchsorted(
+        bin_locations, inputs[..., None],
+        side="right",
+    ) - 1).squeeze(-1)
+    return idx
 
 
 def cbrt(x):

--- a/tests/utils/torchutils_test.py
+++ b/tests/utils/torchutils_test.py
@@ -86,7 +86,7 @@ class TorchUtilsTest(torchtestcase.TorchTestCase):
 
         for inputs in [left_boundaries, right_boundaries, mid_points]:
             with self.subTest(inputs=inputs):
-                idx = torchutils.searchsorted(bin_locations[None, :], inputs)
+                idx = torchutils.searchsorted(bin_locations, inputs)
                 self.assertEqual(idx, torch.arange(0, 9))
 
     def test_searchsorted_arbitrary_shape(self):


### PR DESCRIPTION
Avoid an in place update to the input tensor in `searchsorted`.

Also switch to using `torch.searchsorted`.

**Motivation**

@CChapmanbird and I found a bug where `rational_quadratic_spline`  was returning values outside the valid domain. This caused neural spline flows without tails to occasionally fall over with an input domain error.