### PR TITLE
BUG: fix AMP with splines

### DIFF
--- a/nflows/transforms/splines/cubic.py
+++ b/nflows/transforms/splines/cubic.py
@@ -46,6 +46,7 @@ def unconstrained_cubic_spline(
             inputs=inputs,
             outputs=outputs,
             logabsdet=logabsdet,
+            mask=inside_interval_mask,
             unnormalized_widths=unnormalized_widths[inside_interval_mask, :],
             unnormalized_heights=unnormalized_heights[inside_interval_mask, :],
             unnorm_derivatives_left=unnorm_derivatives_left[inside_interval_mask, :],

--- a/nflows/transforms/splines/cubic.py
+++ b/nflows/transforms/splines/cubic.py
@@ -5,6 +5,7 @@ from torch.nn import functional as F
 
 from ...transforms.base import InputOutsideDomain
 from ...utils import torchutils
+from .utils import apply_spline_at_mask
 
 DEFAULT_MIN_BIN_WIDTH = 1e-3
 DEFAULT_MIN_BIN_HEIGHT = 1e-3
@@ -40,8 +41,11 @@ def unconstrained_cubic_spline(
         raise RuntimeError("{} tails are not implemented.".format(tails))
 
     if torch.any(inside_interval_mask):
-        outputs[inside_interval_mask], logabsdet[inside_interval_mask] = cubic_spline(
-            inputs=inputs[inside_interval_mask],
+        outputs, logabsdet = apply_spline_at_mask(
+            cubic_spline,
+            inputs=inputs,
+            outputs=outputs,
+            logabsdet=logabsdet,
             unnormalized_widths=unnormalized_widths[inside_interval_mask, :],
             unnormalized_heights=unnormalized_heights[inside_interval_mask, :],
             unnorm_derivatives_left=unnorm_derivatives_left[inside_interval_mask, :],

--- a/nflows/transforms/splines/linear.py
+++ b/nflows/transforms/splines/linear.py
@@ -28,6 +28,7 @@ def unconstrained_linear_spline(
             inputs=inputs,
             outputs=outputs,
             logabsdet=logabsdet,
+            mask=inside_interval_mask,
             unnormalized_pdf=unnormalized_pdf[inside_interval_mask, :],
             inverse=inverse,
             left=-tail_bound,

--- a/nflows/transforms/splines/linear.py
+++ b/nflows/transforms/splines/linear.py
@@ -4,6 +4,7 @@ from torch.nn import functional as F
 
 from ...transforms.base import InputOutsideDomain
 from ...utils import torchutils
+from .utils import apply_spline_at_mask
 
 
 def unconstrained_linear_spline(
@@ -22,8 +23,11 @@ def unconstrained_linear_spline(
         raise RuntimeError("{} tails are not implemented.".format(tails))
 
     if torch.any(inside_interval_mask):
-        outputs[inside_interval_mask], logabsdet[inside_interval_mask] = linear_spline(
-            inputs=inputs[inside_interval_mask],
+        outputs, logabsdet = apply_spline_at_mask(
+            linear_spline,
+            inputs=inputs,
+            outputs=outputs,
+            logabsdet=logabsdet,
             unnormalized_pdf=unnormalized_pdf[inside_interval_mask, :],
             inverse=inverse,
             left=-tail_bound,

--- a/nflows/transforms/splines/quadratic.py
+++ b/nflows/transforms/splines/quadratic.py
@@ -42,6 +42,7 @@ def unconstrained_quadratic_spline(
             inputs=inputs,
             outputs=outputs,
             logabsdet=logabsdet,
+            mask=inside_interval_mask,
             unnormalized_widths=unnormalized_widths[inside_interval_mask, :],
             unnormalized_heights=unnormalized_heights[inside_interval_mask, :],
             inverse=inverse,

--- a/nflows/transforms/splines/quadratic.py
+++ b/nflows/transforms/splines/quadratic.py
@@ -3,6 +3,7 @@ from torch.nn import functional as F
 
 from ...transforms.base import InputOutsideDomain
 from ...utils import torchutils
+from .utils import apply_spline_at_mask
 
 DEFAULT_MIN_BIN_WIDTH = 1e-3
 DEFAULT_MIN_BIN_HEIGHT = 1e-3
@@ -36,8 +37,11 @@ def unconstrained_quadratic_spline(
         raise RuntimeError("{} tails are not implemented.".format(tails))
 
     if torch.any(inside_interval_mask):
-        outputs[inside_interval_mask], logabsdet[inside_interval_mask] = quadratic_spline(
-            inputs=inputs[inside_interval_mask],
+        outputs, logabsdet = apply_spline_at_mask(
+            quadratic_spline,
+            inputs=inputs,
+            outputs=outputs,
+            logabsdet=logabsdet,
             unnormalized_widths=unnormalized_widths[inside_interval_mask, :],
             unnormalized_heights=unnormalized_heights[inside_interval_mask, :],
             inverse=inverse,

--- a/nflows/transforms/splines/rational_quadratic.py
+++ b/nflows/transforms/splines/rational_quadratic.py
@@ -4,6 +4,7 @@ from torch.nn import functional as F
 
 from ...transforms.base import InputOutsideDomain
 from ...utils import torchutils
+from .utils import apply_spline_at_mask
 
 DEFAULT_MIN_BIN_WIDTH = 1e-3
 DEFAULT_MIN_BIN_HEIGHT = 1e-3
@@ -40,11 +41,12 @@ def unconstrained_rational_quadratic_spline(
         raise RuntimeError("{} tails are not implemented.".format(tails))
 
     if torch.any(inside_interval_mask):
-        (
-            outputs[inside_interval_mask],
-            logabsdet[inside_interval_mask],
-        ) = rational_quadratic_spline(
-            inputs=inputs[inside_interval_mask],
+        outputs, logabsdet = apply_spline_at_mask(
+            rational_quadratic_spline,
+            inputs=inputs,
+            outputs=outputs,
+            logabsdet=logabsdet,
+            mask=inside_interval_mask,
             unnormalized_widths=unnormalized_widths[inside_interval_mask, :],
             unnormalized_heights=unnormalized_heights[inside_interval_mask, :],
             unnormalized_derivatives=unnormalized_derivatives[inside_interval_mask, :],
@@ -56,8 +58,8 @@ def unconstrained_rational_quadratic_spline(
             min_bin_width=min_bin_width,
             min_bin_height=min_bin_height,
             min_derivative=min_derivative,
-        )
 
+        )
     return outputs, logabsdet
 
 

--- a/nflows/transforms/splines/utils.py
+++ b/nflows/transforms/splines/utils.py
@@ -1,0 +1,33 @@
+
+def apply_spline_at_mask(func, *, inputs, outputs, logabsdet, mask, **kwargs):
+    """Helper function to apply a spline function to a masked subset of inputs.
+
+    Only updates the outputs and logabsdet tensors at the locations specified
+    by the mask.
+
+    Parameters
+    ----------
+    func : Callable
+        The spline function to apply.
+    inputs : torch.Tensor
+        The input tensor.
+    outputs : torch.Tensor
+        The output tensor.
+    logabsdet : torch.Tensor
+        The log absolute determinant tensor.
+    mask : torch.Tensor
+        The mask tensor.
+    **kwargs:
+        Additional keyword arguments to pass to the spline function.
+    """
+    outputs_masked, logabsdet_masked = func(
+        inputs=inputs[mask],
+        **kwargs,
+    )
+    if outputs.dtype == outputs_masked.dtype and logabsdet.dtype == logabsdet_masked.dtype:
+        outputs[mask] = outputs_masked
+        logabsdet[mask] = logabsdet_masked
+    else:
+        outputs[mask] = outputs_masked.to(outputs.dtype)
+        logabsdet[mask] = logabsdet_masked.to(logabsdet.dtype)
+    return outputs, logabsdet


### PR DESCRIPTION
Step 1 to fix the bug described in https://github.com/uofgravity/glasflow/issues/65.

I've opted to introduce a helper function that can be reused between the four spline transforms.

I've tested this via Google Colab and it seems to work. Unfortunately, we can't test AMP in the CI.

Once this is merged, we'll need to update the main glasflow repo to include the fix and make a release.